### PR TITLE
Add .deep.equal and .shallow.includes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 4
+  - 8

--- a/README.md
+++ b/README.md
@@ -70,26 +70,44 @@ jsxChai.options.functions = false;
 
 ---
 
+### Assertions
 
-### Testing Preact Components
+Deep, fully rendered equality/inclusion is checked for: `.deep.equal`, `.eql`, `.include`, and `.contain`
 
-Assertions are supported for both functional and classical components.
-
-Typically, JSX assertions follow a pattern where the component to be tested is passed to `expect()` with any props necessary, and the expected DOM state is passed to `.eql()` (or its alias `.deep.equal()`):
+Shallow, JSX only equality/inclusion is checked for: `.equal`, `.shallow.include`, and `.shallow.contain`
 
 ```js
-// Supports both functional and classical components
-const Link = ({ url, text }) => (
-	<a class="link" href={'/'+href}>Link: { text }</a>
-);
+let Outer = ({a}) => <Inner a={a}/>
+let Innter = ({a}) => <div>{a}</div>
 
-expect(
-	<Link url="?foo" text="foo" />
-).to.eql(
-	<a href="/?foo">Link: foo</a>
-);
+// JSX tests
+expect(<Outer />).to.be.jsx
+expect('Outer').to.not.be.jsx
+
+// Deep equality tests
+expect(<Outer a="foo"/>).to.deep.equal(<Inner a="foo" notRenderedProp="x" />)
+expect(<Outer a="foo"/>).to.deep.equal(<div>foo</div>/>)
+expect(<Outer a="foo"/>).to.not.deep.equal(<Inner a="NotBar"/>)
+expect(<Outer />).to.eql(<Outer />) // .eql is shorthand for .deep.equal
+expect(<Outer a="foo"/>).to.not.eql(<Inner a="NotFoo"/>)
+
+// Shallow Equality tests
+expect(<Outer a="foo"/>).to.equal(<Inner a="foo" />)
+expect(<Outer a="foo"/>).to.not.equal(<Inner a="foo" verifiedJSXProp="x" />)
+expect(<Outer a="foo"/>).to.not.equal(<div>foo</div>) // <Inner /> is not rendered
+
+let WrappedOuter = ({a}) => <div id="outer"><Inner a={a} /></div>
+
+// Deep includes/contains tests
+expect(<WrappedOuter a="foo" />).to.include(<div>foo</div>)
+expect(<WrappedOuter a="foo" />).to.contain(<div>foo</div>)
+expect(<WrappedOuter a="foo" />).to.contain(<Inner a="foo" />)
+expect(<WrappedOuter a="foo" />).to.not.include(<div>Bad Div</div>)
+
+// Shallow includes/contains tests
+expect(<WrappedOuter a="foo" />).to.shallow.contain(<Inner a="foo" />)
+expect(<WrappedOuter a="foo" />).to.not.shallow.include(<div>foo</div>)
 ```
-
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Shallow, JSX only equality/inclusion is checked for: `.equal`, `.shallow.include
 
 ```js
 let Outer = ({a}) => <Inner a={a}/>
-let Innter = ({a}) => <div>{a}</div>
+let Inner = ({a}) => <div>{a}</div>
 
 // JSX tests
 expect(<Outer />).to.be.jsx

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "typings": "src/index.d.ts",
   "scripts": {
     "build": "babel src -s inline -d dist",
-    "test": "eslint {src,test} && mocha --compilers js:babel/register test/**/*.js",
+    "test": "npm run -s lint && npm run -s test:unit",
+    "lint": "eslint src test",
+    "test:unit": "mocha --compilers js:babel/register test/**/*.js",
     "prepublish": "npm run build",
     "release": "npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import render from 'preact-render-to-string/jsx';
+import {util} from 'chai';
 
 /** Options for all assertions.
  *	@property {function} isJsx					A test to see if the given parameter is a JSX VNode. Defaults to checking for the existence of an __isVNode property
@@ -33,6 +34,26 @@ const INCLUDE_RENDER_OPTS = {
 	pretty: false
 };
 
+const SHALLOW_INCLUDE_OPTS = {
+	...INCLUDE_RENDER_OPTS,
+	shallow: true
+};
+
+const SHALLOW_INCLUDE_OPTS_EXPECTED = {
+	...SHALLOW_INCLUDE_OPTS,
+	renderRootComponent: false
+};
+
+// The options for 'equal' and 'equals' change depending on whether the deep flag has been set with .deep prop
+let getEqualOpts = (obj) => {
+	return util.flag(obj, 'deep') ? [RENDER_OPTS] : [SHALLOW_OPTS, SHALLOW_OPTS_EXPECTED];
+};
+
+// The options for 'includes' and 'contains' change depending on whether 'shallow' flag has been set with .shallow prop
+let getIncludeOpts = (obj) => {
+	return util.flag(obj, 'shallow') ? [SHALLOW_INCLUDE_OPTS, SHALLOW_INCLUDE_OPTS_EXPECTED] : [INCLUDE_RENDER_OPTS, INCLUDE_RENDER_OPTS, RENDER_OPTS];
+};
+
 // create an assertion template string for the given action
 let msg = act => `expected #{act} to ${act} #{exp}`;
 
@@ -51,9 +72,14 @@ let doRender = (jsx, opts) => render(jsx, null, {
 
 // inject a chai assertion if the values being tested are JSX VNodes
 let ifJsx = (fn, opts, optsExpected, displayOpts) => next => function(jsx, ...args) {
+	let resolvedOpts = opts;
+	if (typeof opts === 'function') {
+		([resolvedOpts, optsExpected, displayOpts] = opts(this));
+	}
+
 	if (!isJsx(this._obj)) return next.call(this, jsx, ...args);
-	let actual = doRender(this._obj, opts).trim();
-	let expected = doRender(jsx, optsExpected || opts).trim();
+	let actual = doRender(this._obj, resolvedOpts).trim();
+	let expected = doRender(jsx, optsExpected || resolvedOpts).trim();
 	let diffActual = displayOpts ? doRender(this._obj, displayOpts).trim() : actual;
 	let diffExpected = displayOpts ? doRender(jsx, displayOpts).trim() : expected;
 	return fn(this, { expected, actual, diffActual, diffExpected, jsx });
@@ -68,7 +94,6 @@ let equal = (a, { expected, actual, diffExpected, diffActual }) => a.assert(actu
 // assert that a String contains the given string
 let include = (a, { expected, actual, diffExpected, diffActual }) => a.assert(~actual.indexOf(expected), msg('include'), msg('not include'), diffExpected, diffActual, true);
 
-
 /** Middleware: pass to `chai.use()` to add JSX assertion support. */
 export default function assertJsx({ Assertion }) {
 	if (Assertion.__assertJsxMounted===true) return;
@@ -77,11 +102,22 @@ export default function assertJsx({ Assertion }) {
 	Assertion.overwriteMethod('eql', ifJsx(equal, RENDER_OPTS));
 	Assertion.overwriteMethod('eqls', ifJsx(equal, RENDER_OPTS));
 
-	Assertion.overwriteMethod('equal', ifJsx(equal, SHALLOW_OPTS, SHALLOW_OPTS_EXPECTED));
-	Assertion.overwriteMethod('equals', ifJsx(equal, SHALLOW_OPTS, SHALLOW_OPTS_EXPECTED));
+	Assertion.overwriteMethod('equal', ifJsx(equal, getEqualOpts));
+	Assertion.overwriteMethod('equals', ifJsx(equal, getEqualOpts));
+
+	Assertion.addProperty('shallow', function () {
+		util.flag(this, 'shallow', true);
+	});
+
+	Assertion.addProperty('jsx',  function () {
+		this.assert(
+			isJsx(this._obj),
+			'expected #{this} to be jsx',
+			'expected #{this} to not be jsx');
+	});
 
 	['include', 'includes', 'contain', 'contains'].forEach( method => {
-		Assertion.overwriteChainableMethod(method, ifJsx(include, INCLUDE_RENDER_OPTS, INCLUDE_RENDER_OPTS, RENDER_OPTS), through);
+		Assertion.overwriteChainableMethod(method, ifJsx(include, getIncludeOpts), through);
 	});
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -146,7 +146,6 @@ describe('preact-jsx-chai', () => {
 		it('should ignore functions when functions=false', () => {
 			let before = options.functions;
 			options.functions = false;
-			console.log("Options in test is", options);
 
 			expect(<div onClick={() => {}} />).to.eql(<div />);
 			expect(<div onClick={() => {}} />).to.equal(<div />);

--- a/test/index.js
+++ b/test/index.js
@@ -2,12 +2,14 @@ import assertJsx, { options } from '../src';
 import { h, Component } from 'preact';
 import { expect, default as chai } from 'chai';
 chai.use(assertJsx);
+
 /**@jsx h */
 
 /*eslint-env mocha */
 /*eslint max-nested-callbacks:0*/
 
 describe('preact-jsx-chai', () => {
+
 	describe('assertJsx()', () => {
 		it('should be a function', () => {
 			expect(assertJsx).to.be.a('function');
@@ -55,13 +57,28 @@ describe('preact-jsx-chai', () => {
 		});
 	});
 
-	describe('shallow', () => {
-		it('should render shallow for .equal()', () => {
+	describe('jsx', () => {
+		it('should support the .jsx property to test if the object is jsx', () => {
+			expect(<div>Foo</div>).to.be.jsx;
+			expect({
+				nodeName: 'jsx',
+				attributes: undefined,
+				children: undefined
+			}).to.not.be.jsx;
+			expect(1).to.not.be.jsx;
+
+			let Foo = () => <div>My Component</div>;
+			expect(<Foo bar={1} />).to.be.jsx;
+		});
+	});
+
+	describe('equality', () => {
+		it('should render shallow for .equal() and sort props for comparison', () => {
 			// example component that, if rendered, would never be equal
 			let counter = 0;
-			const Outer = () => <Inner b="b" />;
+			const Outer = () => <Inner b="b" c="c"/>;
 			const Inner = ({ b }) => <span b1={b}>{++counter}</span>;
-			expect(<Outer a />).to.equal(<Inner b="b" />);
+			expect(<Outer a />).to.equal(<Inner  c="c"  b="b" />);
 		});
 
 		it('should render deeply for .eql() / .deep.equal()', () => {
@@ -70,7 +87,9 @@ describe('preact-jsx-chai', () => {
 			const Outer = () => <Inner b="b" />;
 			const Inner = ({ b }) => <span b1={b}>{++counter}</span>;
 			expect(<Outer />).to.eql(<span b1="b">1</span>);
+			expect(<Outer />).to.deep.equal(<span b1="b">2</span>);
 			expect(<Outer a />).not.to.eql(<Outer b />);
+			expect(<Outer a />).not.to.deep.equal(<Outer b />);
 		});
 
 		it('should shallow-compare components with complex props', () => {
@@ -86,18 +105,48 @@ describe('preact-jsx-chai', () => {
 		});
 	});
 
+	describe('includes/contains', () => {
+		it('should render deeply for contains and includes', () => {
+			const Outer = ({count}) => <Inner count={count+1} />;
+			const Inner = ({ count }) => <span b={count}><i>{count}</i></span>;
+
+			expect(<Outer count={0} />, "include method").to.include(<i>{1}</i>);
+			expect(<Outer count={0} />, "includes method").includes(<i>{1}</i>);
+			expect(<Outer count={0}/>, "contain method").to.contain(<i>1</i>);
+			expect(<Outer count={0}/>, "contains method").to.contains(<i>1</i>);
+			expect(<Outer count={0}/>, "bigger inner contains").contains(<span b={1}><i>{1}</i></span>);
+			expect(<Outer count={0}/>, "expectation and actual should both be deeply rendered").to.include(<Inner count={1} />);
+			expect(<Outer count={0}/>, "expectation and actual should both be deeply rendered").to.not.include(<Inner count={7} />);
+		});
+
+		it('should render and check inclusion shallow when .shallow property is used', () => {
+			const Outer = () => <div foo="bar"><Inner b="b" c="c" /></div>;
+			const Inner = () => <span>Buzz</span>;
+			expect(<Outer a />, "props were out of order").to.shallow.contain(<Inner c="c"  b="b" />);
+			expect(<Outer a />, "bigger shallow diff").to.shallow.contain(<div foo="bar"><Inner b="b" c="c"/></div>);
+			expect(<Outer a />, "include method works").to.shallow.include(<Inner b="b" c="c"/>);
+			expect(<Outer a />, "Inner should not be deep rendered").to.not.shallow.include(<span>Buzz</span>);
+
+		});
+	});
+
 	describe('options', () => {
 		it('should be an object', () => {
 			expect(options).to.be.an('object');
 		});
 
-		xit('should support isJsx()', () => {
-			// @TODO
+		it('should support isJsx() override', () => {
+			expect(<div />).to.be.jsx;
+			options.isJsx = (val) => val === 'I promise I am JSX';
+			expect(<div />).to.not.be.jsx;
+			expect('I promise I am JSX').to.be.jsx;
+			delete options.isJsx;
 		});
 
 		it('should ignore functions when functions=false', () => {
 			let before = options.functions;
 			options.functions = false;
+			console.log("Options in test is", options);
 
 			expect(<div onClick={() => {}} />).to.eql(<div />);
 			expect(<div onClick={() => {}} />).to.equal(<div />);


### PR DESCRIPTION
This PR takes care of some maintenance issues and adds some new piece functionality as well:

1. **BUG FIX**: Actually implements `.deep.equal`.  It was in the README as working but wasn't actually implemented or tested before.  I implemented and tested it
2. **NEW TESTS**: Add tests for `options.isJsx`override function (the implementation already worked)
3. **NEW FEATURE**: Added implementation and tests for the `.to.be.jsx` property for compatibility with `jsx-chai` library
4. **NEW FEATURE**: Added implementation and tests for a new shallow includes/contains test that does inclusion check on shallow rendered JSX.  This is not in `jsx-chai` but I find myself needing it frequently and think it is a useful addition
5. **MAINTENANCE** - Update README with more comprehensive assertions documentations

