### PR TITLE
Support for Preact X

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "preact": "^10.0.0-beta.2"
   },
   "dependencies": {
-    "preact-render-to-string": "^3.2.0"
+    "preact-render-to-string": "^5.0.3"
   },
   "greenkeeper": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint": "^4.0.0",
     "eslint-plugin-react": "^7.0.0",
     "mocha": "^3.0.0",
-    "preact": "^8.1.0"
+    "preact": "^10.0.0-beta.2"
   },
   "dependencies": {
     "preact-render-to-string": "^3.2.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import render from 'preact-render-to-string/jsx';
 
 /** Options for all assertions.
- *	@property {function} isJsx					A test to see if the given parameter is a JSX VNode. Defaults to checking for the existence of an __isVNode property
+ *	@property {function} isJsx					A test to see if the given parameter is a JSX VNode. Defaults to checking for the existence of a _vnode property
  */
 export const options = {
 	/* If `false`, props with function values will be omitted from the comparison entirely */
@@ -37,10 +37,10 @@ const INCLUDE_RENDER_OPTS = {
 let msg = act => `expected #{act} to ${act} #{exp}`;
 
 // assert that an object is JSX (or more correctly, a VNode)
-let isJsx = obj => obj && (options.isJsx ? options.isJsx(obj) : (obj.__isVNode || isVNode(obj)));
+let isJsx = obj => obj && (options.isJsx ? options.isJsx(obj) : (obj._vnode || isVNode(obj)));
 
 // does it look like a vnode?
-let isVNode = obj => obj.hasOwnProperty('nodeName') && obj.hasOwnProperty('attributes') && obj.hasOwnProperty('children') && obj.constructor.name==='VNode';
+let isVNode = obj => obj.hasOwnProperty('type') && obj.hasOwnProperty('props');
 
 // inject default options and invoke render with no context
 let doRender = (jsx, opts) => render(jsx, null, {

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
 import assertJsx, { options } from '../src';
-import { h, Component } from 'preact';
+import { createElement, Component } from 'preact';
 import { expect, default as chai } from 'chai';
 chai.use(assertJsx);
-/**@jsx h */
+/**@jsx createElement */
 
 /*eslint-env mocha */
 /*eslint max-nested-callbacks:0*/
@@ -24,13 +24,12 @@ describe('preact-jsx-chai', () => {
 
 			it('not be triggered when JSX is not tested', () => {
 				expect(<jsx />).to.deep.equal({
-					nodeName: 'jsx',
-					attributes: undefined,
-					children: undefined
+					type: 'jsx',
+					props: undefined
 				});
 			});
 
-			it('should sort attributes', () => {
+			it('should sort props', () => {
 				expect(<jsx a="a" b="b" c="c" />).to.eql(<jsx c="c" b="b" a="a" />);
 			});
 		});


### PR DESCRIPTION
It looks like the shape of a VNode has changed, so `preact-jsx-chai` has stopped finding VNodes and the calls to `expect(...).to.eql(...)` have stopped working correctly.

Still working on getting all the tests to pass.

**TODO:**
- [ ] Tests