### PR TITLE
Revert preact X targeted changes in 2.x branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint": "^4.0.0",
     "eslint-plugin-react": "^7.0.0",
     "mocha": "^3.0.0",
-    "preact": "10.0.0-beta.3"
+    "preact": "^8.1.0"
   },
   "dependencies": {
     "preact-render-to-string": "^5.0.4"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
   "dependencies": {
     "preact-render-to-string": "^4.1.0"
   },
+  "peerDependencies": {
+    "preact": "<10"
+  },
   "greenkeeper": {
     "ignore": [
       "babel",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "preact": "^8.1.0"
   },
   "dependencies": {
-    "preact-render-to-string": "^5.0.4"
+    "preact-render-to-string": "^4.1.0"
   },
   "greenkeeper": {
     "ignore": [

--- a/src/index.js
+++ b/src/index.js
@@ -61,11 +61,7 @@ let msg = act => `expected #{act} to ${act} #{exp}`;
 let isJsx = obj => obj && (options.isJsx ? options.isJsx(obj) : (obj.__isVNode || isVNode(obj)));
 
 // does it look like a vnode?
-<<<<<<< HEAD
 let isVNode = obj => obj.hasOwnProperty('nodeName') && obj.hasOwnProperty('attributes') && obj.hasOwnProperty('children') && obj.constructor.name==='VNode';
-=======
-let isVNode = obj => obj.hasOwnProperty('nodeName') && obj.hasOwnProperty('attributes') && Array.isArray(obj.children);
->>>>>>> 443e2c2cef21fb6a7189bf6a7a216a2852f77b4f
 
 // inject default options and invoke render with no context
 let doRender = (jsx, opts) => render(jsx, null, {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import render from 'preact-render-to-string/jsx';
 import {util} from 'chai';
 
 /** Options for all assertions.
- *	@property {function} isJsx					A test to see if the given parameter is a JSX VNode. Defaults to checking for the existence of a _vnode property
+ *	@property {function} isJsx					A test to see if the given parameter is a JSX VNode. Defaults to checking for the existence of an __isVNode property
  */
 export const options = {
 	/* If `false`, props with function values will be omitted from the comparison entirely */
@@ -58,10 +58,10 @@ let getIncludeOpts = (obj) => {
 let msg = act => `expected #{act} to ${act} #{exp}`;
 
 // assert that an object is JSX (or more correctly, a VNode)
-let isJsx = obj => obj && (options.isJsx ? options.isJsx(obj) : (obj._vnode || isVNode(obj)));
+let isJsx = obj => obj && (options.isJsx ? options.isJsx(obj) : (obj.__isVNode || isVNode(obj)));
 
 // does it look like a vnode?
-let isVNode = obj => obj.hasOwnProperty('type') && obj.hasOwnProperty('props') && obj.hasOwnProperty('key') && obj.hasOwnProperty('ref');
+let isVNode = obj => obj.hasOwnProperty('nodeName') && obj.hasOwnProperty('attributes') && obj.hasOwnProperty('children') && obj.constructor.name==='VNode';
 
 // inject default options and invoke render with no context
 let doRender = (jsx, opts) => render(jsx, null, {

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,8 @@
 import assertJsx, { options } from '../src';
-import { createElement, Component } from 'preact';
+import { h, Component } from 'preact';
 import { expect, default as chai } from 'chai';
 chai.use(assertJsx);
-
-/**@jsx createElement */
+/**@jsx h */
 
 /*eslint-env mocha */
 /*eslint max-nested-callbacks:0*/
@@ -26,12 +25,13 @@ describe('preact-jsx-chai', () => {
 
 			it('not be triggered when JSX is not tested', () => {
 				expect(<jsx />).to.deep.equal({
-					type: 'jsx',
-					props: undefined
+					nodeName: 'jsx',
+					attributes: undefined,
+					children: undefined
 				});
 			});
 
-			it('should sort props', () => {
+			it('should sort attributes', () => {
 				expect(<jsx a="a" b="b" c="c" />).to.eql(<jsx c="c" b="b" a="a" />);
 			});
 		});


### PR DESCRIPTION
When the 2.x branch was created to support preact 8, it looks like some of the Preact X only PRs were included with it.  I reverted their commits and did some final touch up to ensure it is compatible with preact 8.  

We need to get this merged and released ASAP as the 2.3.0 release is breaking people using Preact 8.